### PR TITLE
filter out unsuccessful runs

### DIFF
--- a/matilda/readfromtiled.py
+++ b/matilda/readfromtiled.py
@@ -299,7 +299,7 @@ def FindLastBlankScan(plan_name,path=None, NumScans=1, lastNdays=0):
     logging.info(f"{uri=}")
 
     
-   
+    try:
         r = requests.get(uri).json()
         #print(f'Search of {catalog=} has {len(r["data"])} runs.')
         #print_results_summary(r)
@@ -376,7 +376,7 @@ def FindLastScanData(plan_name,NumScans=10, LastNdays=1):
           
     logging.info(f"{uri=}")
     #print(f"{uri=}")
-   
+    try:
         r = requests.get(uri).json()
         # this is now a list of Flyscan data sets
         ScanList = convert_results(r)


### PR DESCRIPTION
- closes #9

When building a list of scans, only add scans that have exited successfully.